### PR TITLE
Remove unnecessary \n in makefile

### DIFF
--- a/DiscImageCreator/makefile
+++ b/DiscImageCreator/makefile
@@ -74,6 +74,6 @@ buildDateTime:
 	echo "\"" >>buildDateTime.h
 	echo -n "#define BUILD_TIME \"" >>buildDateTime.h
 	date +%H%M%S | tr -d '\n' >>buildDateTime.h
-	echo "\"\n" >>buildDateTime.h
+	echo "\"" >>buildDateTime.h
 
 .PHONY: clean clean-objs buildDateTime


### PR DESCRIPTION
This pull request removes a *\n* in the makefile function *buildDateTime* causing build errors on Linux.

```
In file included from DiscImageCreator.cpp:18:
buildDateTime.h:4:28: error: stray '\' in program
 #define BUILD_TIME "162841"\n
                            ^
```

```
In file included from DiscImageCreator.cpp:18:
DiscImageCreator.cpp: In function 'int printSeveralInfo(LPTSTR, size_t)':
buildDateTime.h:4:29: error: expected ')' before 'n'
 #define BUILD_TIME "162841"\n
                             ^
```

**Before (buildDateTime.h):**
```
#define BUILD_TIME "162533"\n
```

**After (buildDateTime.h):**
```
#define BUILD_TIME "162617"
```