### PR TITLE
makefile: make buildDateTime.h generation a bit more portable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ ipch/
 .vs/
 DiscImageCreator.VC.*
 DiscImageCreator.vcxproj.user
+DiscImageCreator/buildDateTime.h

--- a/DiscImageCreator/makefile
+++ b/DiscImageCreator/makefile
@@ -67,13 +67,13 @@ clean:
 	rm -f buildDateTime.h
 
 buildDateTime:
-	echo "#pragma once" >buildDateTime.h
-	echo >>buildDateTime.h
-	echo -n "#define BUILD_DATE \"" >>buildDateTime.h
-	date +%Y%m%d | tr -d '\n' >>buildDateTime.h
-	echo "\"" >>buildDateTime.h
-	echo -n "#define BUILD_TIME \"" >>buildDateTime.h
-	date +%H%M%S | tr -d '\n' >>buildDateTime.h
-	echo "\"" >>buildDateTime.h
+	$(shell /usr/bin/env echo "#pragma once" >buildDateTime.h)
+	$(shell /usr/bin/env echo >>buildDateTime.h)
+	$(shell /usr/bin/env echo -n "#define BUILD_DATE \"" >>buildDateTime.h)
+	$(shell date +%Y%m%d | tr -d '\n' >>buildDateTime.h)
+	$(shell /usr/bin/env echo "\"" >>buildDateTime.h)
+	$(shell /usr/bin/env echo -n "#define BUILD_TIME \"" >>buildDateTime.h)
+	$(shell date +%H%M%S | tr -d '\n' >>buildDateTime.h)
+	$(shell /usr/bin/env echo "\"" >>buildDateTime.h)
 
 .PHONY: clean clean-objs buildDateTime


### PR DESCRIPTION
I ran into issues on a system where `echo` is a shell builtin under `/bin/sh`, but the `-n` flag wasn't supported. The system *does* come with a `/bin/echo` that supports `-n` though; changing the `buildDateTime` target to make sure it's executed via the program instead of the shell builtin fixes it. Should be equally portable to the systems this was originally written for.

I also added the generated `buildDateTime.h` to the gitignore.