### PR TITLE
fixed linux build and enhanced gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,11 @@ ipch/
 DiscImageCreator.VC.*
 DiscImageCreator.vcxproj.user
 DiscImageCreator/buildDateTime.h
+
+# generated linux obj files
+DiscImageCreator/*.o
+DiscImageCreator/_external/*.o
+DiscImageCreator/_linux/*.o
+
+# linux binary
+DiscImageCreator/DiscImageCreator

--- a/DiscImageCreator/makefile
+++ b/DiscImageCreator/makefile
@@ -44,6 +44,8 @@ SOURCES_CXX := \
   _external/prngcd.o \
   _external/rijndael-alg-fst.o \
   _external/sha1.o \
+  _external/tinyxml2.o \
+  xml.o \
   _linux/defineForLinux.o
 
 OBJECTS := $(SOURCES_C:.c=.o) $(SOURCES_CXX:.cpp=.o)


### PR DESCRIPTION
* now xml and tinyxml objects will be built when calling with make
* objects and resulting linux binary are now ignored by git