### PR TITLE
Implement reading from default directories

### DIFF
--- a/DiscImageCreator/_linux/defineForLinux.cpp
+++ b/DiscImageCreator/_linux/defineForLinux.cpp
@@ -154,7 +154,7 @@ void _makepath(char* Path, const char* Drive, const char* Directory,
 
 int PathSet(char* path, char const* fullpath)
 {
-       strcat(path, fullpath);
+       strcpy(path, fullpath);
 
        return 1; /* not sure when this function would 'fail' */
 }

--- a/DiscImageCreator/_linux/defineForLinux.cpp
+++ b/DiscImageCreator/_linux/defineForLinux.cpp
@@ -152,6 +152,13 @@ void _makepath(char* Path, const char* Drive, const char* Directory,
 	return;
 }
 
+int PathSet(char* path, char const* fullpath)
+{
+       strcat(path, fullpath);
+
+       return 1; /* not sure when this function would 'fail' */
+}
+
 // http://stackoverflow.com/questions/3218201/find-a-replacement-for-windows-pathappend-on-gnu-linux
 int PathAppend(char* path, char const* more)
 {

--- a/DiscImageCreator/_linux/defineForLinux.h
+++ b/DiscImageCreator/_linux/defineForLinux.h
@@ -2219,6 +2219,8 @@ void _makepath(char* Path, const char* Drive, const char* Directory, const char*
 // http://stackoverflow.com/questions/3218201/find-a-replacement-for-windows-pathappend-on-gnu-linux
 int PathAppend(char* path, char const* more);
 
+int PathSet(char* path, char const* fullpath);
+
 // https://www.quora.com/How-do-I-check-if-a-file-already-exists-using-C-file-I-O
 int PathFileExists(const char *filename);
 

--- a/DiscImageCreator/makefile
+++ b/DiscImageCreator/makefile
@@ -83,4 +83,13 @@ buildDateTime:
 	$(shell date +%H%M%S | tr -d '\n' >>buildDateTime.h)
 	$(shell /usr/bin/env echo "\"" >>buildDateTime.h)
 
+ifeq ($(PREFIX),)
+    PREFIX := /usr/local
+endif
+
+install:
+	install -d $(DESTDIR)$(PREFIX)/DiscImageCreator/
+	install -Dm 0644 ../Release_ANSI/default.dat $(DESTDIR)$(PREFIX)/share/DiscImageCreator/default.dat
+	install -m 755 $(TARGET) $(DESTDIR)$(PREFIX)/bin/
+
 .PHONY: clean clean-objs buildDateTime

--- a/DiscImageCreator/xml.cpp
+++ b/DiscImageCreator/xml.cpp
@@ -390,17 +390,25 @@ BOOL ReadWriteDat(
 	}
 #else
 	CHAR szDefaultDat[_MAX_PATH] = {};
-	if (!GetModuleFileName(NULL, szDefaultDat, sizeof(szDefaultDat) / sizeof(szDefaultDat[0]))) {
-		OutputLastErrorNumAndString(_T(__FUNCTION__), __LINE__);
-		return FALSE;
+	if (PathFileExists("/usr/local/share/DiscImageCreator/default.dat")) {
+		PathSet(szDefaultDat, "/usr/local/share/DiscImageCreator/default.dat");
 	}
-	if (!PathRemoveFileSpec(szDefaultDat)) {
-		OutputLastErrorNumAndString(_T(__FUNCTION__), __LINE__);
-		return FALSE;
+	else if (PathFileExists("/usr/share/DiscImageCreator/default.dat")) {
+		PathSet(szDefaultDat, "/usr/share/DiscImageCreator/default.dat");
 	}
-	if (!PathAppend(szDefaultDat, "default.dat")) {
-		OutputLastErrorNumAndString(_T(__FUNCTION__), __LINE__);
-		return FALSE;
+	else {
+		if (!GetModuleFileName(NULL, szDefaultDat, sizeof(szDefaultDat) / sizeof(szDefaultDat[0]))) {
+			OutputLastErrorNumAndString(_T(__FUNCTION__), __LINE__);
+			return FALSE;
+		}
+		if (!PathRemoveFileSpec(szDefaultDat)) {
+			OutputLastErrorNumAndString(_T(__FUNCTION__), __LINE__);
+			return FALSE;
+		}
+		if (!PathAppend(szDefaultDat, "default.dat")) {
+			OutputLastErrorNumAndString(_T(__FUNCTION__), __LINE__);
+			return FALSE;
+		}
 	}
 
 	XMLDocument xmlReader;


### PR DESCRIPTION
This adds `/usr/local/share/DiscImageCreator` and `/usr/share/DiscImageCreator`as a search path for default.dat xml file.
This is useful for packaging purposes

I also added a install command to the makefile.
So DiscImageCreator can be packaged easily.

Also fixes #31 