### PR TITLE
fix createCmdFile arg

### DIFF
--- a/DiscImageCreator/DiscImageCreator.cpp
+++ b/DiscImageCreator/DiscImageCreator.cpp
@@ -1810,7 +1810,7 @@ int main(int argc, char* argv[])
 			OutputString("StartTime: %s\n", szBuf);
 
 			if (execType != merge) {
-				nRet = createCmdFile(argc, argv, szFullPath, szDateTime);
+				nRet = createCmdFile(argc, argv, szFullPath, szBuf);
 			}
 			if (nRet) {
 				nRet = exec(argv, &execType, &extArg, szFullPath);

--- a/DiscImageCreator/DiscImageCreator.cpp
+++ b/DiscImageCreator/DiscImageCreator.cpp
@@ -1531,7 +1531,7 @@ int checkArg(int argc, _TCHAR* argv[], PEXEC_TYPE pExecType, PEXT_ARG pExtArg, _
 int createCmdFile(int argc, _TCHAR* argv[], _TCHAR* pszFullPath, LPTSTR pszDateTime)
 {
 	if (argc >= 4) {
-		_TCHAR date[17] = {};
+		_TCHAR date[25] = {};
 		_sntprintf(date, sizeof(date) / sizeof(_TCHAR), _T("_%s"), pszDateTime);
 		FILE* fpCmd = CreateOrOpenFile(
 			pszFullPath, date, NULL, NULL, NULL, _T(".txt"), _T(WFLAG), 0, 0);
@@ -1806,7 +1806,7 @@ int main(int argc, char* argv[])
 			_TCHAR szBuf[128] = {};
 			time_t now = time(NULL);
 			tm* ts = localtime(&now);
-			_tcsftime(szBuf, sizeof(szBuf) / sizeof(szBuf[0]), _T("%FT%T%z"), ts);
+			_tcsftime(szBuf, sizeof(szBuf) / sizeof(szBuf[0]), _T("%FT%H-%M-%S%z"), ts);
 			OutputString("StartTime: %s\n", szBuf);
 
 			if (execType != merge) {
@@ -1818,7 +1818,7 @@ int main(int argc, char* argv[])
 
 			now = time(NULL);
 			ts = localtime(&now);
-			_tcsftime(szBuf, sizeof(szBuf) / sizeof(szBuf[0]), _T("%FT%T%z"), ts);
+			_tcsftime(szBuf, sizeof(szBuf) / sizeof(szBuf[0]), _T("%FT%H-%M-%S%z"), ts);
 			OutputString("EndTime: %s\n", szBuf);
 		}
 		if (!extArg.byQuiet) {


### PR DESCRIPTION
The dump date file is using the compile time variable rather than the current time variable.

before:
```
AppVersion
        x86, AnsiBuild, 10/2/221T173132
StartTime: 2021-10-29T17:31:34-0400
createoropen: F:\xxx\DiscImageCreator-master\Release_ANSI\dump1_10/2/221T173132.txt
[F:createCmdFile][L:1521] GetLastError: 3, The system cannot find the path specified.
```
(fails since there's slashes, expecting directory)

after:
```
AppVersion
        x86, AnsiBuild, 10/2/221T173510
StartTime: 2021-10-29T17:35:12-0400
createoropen: F:\xxx\dump1_2021-10-29T17:35.txt
<succeeds>
```