### PR TITLE
Added Shift JIS hint

### DIFF
--- a/DiscImageCreator/execScsiCmdforCDCheck.cpp
+++ b/DiscImageCreator/execScsiCmdforCDCheck.cpp
@@ -13,6 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+ /* Please note, this file should be opened with Shift JIS encoding
+ * due to the Japanese text in ReadCDForScanningPsxAntiMod().
+ * This sample text is high up in this file to allow some editors
+ * to autodetect encoding:
+ * 		"強制終了しました。\n本体が改造されている\nおそれがあります。";
+ */
+
 #include "struct.h"
 #include "calcHash.h"
 #include "check.h"


### PR DESCRIPTION
I had a problem where I accidentally corrupted some text by editing execScsiCmdforCDCheck.cpp in UTF-8 rather than Shift JIS in Visual Studio Code. I found that VScode has an option to autodetect encoding, but it only checks the first few hundred bytes, so I have added this comment near the top of the file to help. This may help with other editors that autodetect encoding too.