### PR TITLE
Remove printing directory from .dat output file

### DIFF
--- a/DiscImageCreator/xml.cpp
+++ b/DiscImageCreator/xml.cpp
@@ -805,7 +805,7 @@ BOOL ReadWriteDat(
 			XMLElement* newElem2 = newElem1->GetDocument()->NewElement(readElem2->Name());
 			if (readElem2->GetText() == NULL) {
 				if (!strcmp(readElem2->Name(), "game")) {
-					newElem2->SetAttribute("name", szDir);
+					newElem2->SetAttribute("name", "-insert name-");
 				}
 				else {
 					newElem2->SetText("\n");
@@ -824,7 +824,7 @@ BOOL ReadWriteDat(
 				}
 				else {
 					if (!strcmp(readElem3->Name(), "description") && !strcmp(readElem2->Name(), "game")) {
-						newElem3->SetText(szDir);
+						newElem3->SetText("-insert description-");
 						bDescription = TRUE;
 					}
 					else {


### PR DESCRIPTION
Currently when a disc is dumped, the .dat file that gets created alongside the dumped file will contain a game name and description field. These fields get filled in with the full working directory where DIC was invoked. This does not align with the fields, and additionally releases a user's file structure which, while not dangerous, is unnecessary personal data being shared which is unrelated to the disc being dumped.

This pull request simply changes the two lines in the code that had inserted those values, to instead insert strings matching the default.dat file. A better long-term solution would be if default.dat were modified to include the "insert name" and "insert description fields", so that all the code has to touch is the line containing the checksums, but for now simply patching out the segment of code which writes the user's directory into the file should be sufficient.