### PR TITLE
Fix Kreon dumps on Linux with CDB10 for libata

### DIFF
--- a/DiscImageCreator/execScsiCmdforDVD.cpp
+++ b/DiscImageCreator/execScsiCmdforDVD.cpp
@@ -1958,7 +1958,7 @@ BOOL GetFeatureListForXBox(
 	PEXT_ARG pExtArg,
 	PDEVICE pDevice
 ) {
-	BYTE lpCmd[CDB6GENERIC_LENGTH] = {};
+	BYTE lpCmd[CDB10GENERIC_LENGTH] = {};
 	lpCmd[0] = 0xff;
 	lpCmd[1] = 0x08;
 	lpCmd[2] = 0x01;
@@ -1972,7 +1972,7 @@ BOOL GetFeatureListForXBox(
 	INT direction = SG_DXFER_FROM_DEV;
 #endif
 	BYTE scsiStatus = 0;
-	if (!ScsiPassThroughDirect(pExtArg, pDevice, lpCmd, CDB6GENERIC_LENGTH,
+	if (!ScsiPassThroughDirect(pExtArg, pDevice, lpCmd, CDB10GENERIC_LENGTH,
 		buf, direction, 26, &scsiStatus, _T(__FUNCTION__), __LINE__, TRUE)
 		|| scsiStatus >= SCSISTAT_CHECK_CONDITION) {
 		return FALSE;
@@ -2032,7 +2032,7 @@ BOOL SetLockState(
 	PDEVICE pDevice,
 	BYTE byState
 ) {
-	BYTE lpCmd[CDB6GENERIC_LENGTH] = {};
+	BYTE lpCmd[CDB10GENERIC_LENGTH] = {};
 	lpCmd[0] = 0xff;
 	lpCmd[1] = 0x08;
 	lpCmd[2] = 0x01;
@@ -2045,7 +2045,7 @@ BOOL SetLockState(
 	INT direction = SG_DXFER_NONE;
 #endif
 	BYTE scsiStatus = 0;
-	if (!ScsiPassThroughDirect(pExtArg, pDevice, lpCmd, CDB6GENERIC_LENGTH,
+	if (!ScsiPassThroughDirect(pExtArg, pDevice, lpCmd, CDB10GENERIC_LENGTH,
 		NULL, direction, 0, &scsiStatus, _T(__FUNCTION__), __LINE__, TRUE)
 		|| scsiStatus >= SCSISTAT_CHECK_CONDITION) {
 		return FALSE;
@@ -2063,7 +2063,7 @@ BOOL SetErrorSkipState(
 	PDEVICE pDevice,
 	BYTE byState
 ) {
-	BYTE lpCmd[CDB6GENERIC_LENGTH] = {};
+	BYTE lpCmd[CDB10GENERIC_LENGTH] = {};
 	lpCmd[0] = 0xff;
 	lpCmd[1] = 0x08;
 	lpCmd[2] = 0x01;
@@ -2076,7 +2076,7 @@ BOOL SetErrorSkipState(
 	INT direction = SG_DXFER_NONE;
 #endif
 	BYTE scsiStatus = 0;
-	if (!ScsiPassThroughDirect(pExtArg, pDevice, lpCmd, CDB6GENERIC_LENGTH,
+	if (!ScsiPassThroughDirect(pExtArg, pDevice, lpCmd, CDB10GENERIC_LENGTH,
 		NULL, direction, 0, &scsiStatus, _T(__FUNCTION__), __LINE__, TRUE)
 		|| scsiStatus >= SCSISTAT_CHECK_CONDITION) {
 		return FALSE;


### PR DESCRIPTION
Bug fix for Kreon xbox dumps on Linux

Kreon dumps with the Linux build of DIC currently fail to match redump when using direct SATA connection (when using `libata`).
This is because the lock state command does not work as libata expects a CDB command 10 long for vendor specific commands (0xFF): https://github.com/torvalds/linux/blob/master/drivers/ata/libata-scsi.c#L4199
This PR ensures the Kreon commands are CDB10, which fixes DIC Kreon dumps on Linux (and maybe MacOS)

This PR follows work done by @tbejos to support Kreon dumping in redumper.