### PR TITLE
execScsiCmd: do not request CD-Text on 32ts and 20ts

### DIFF
--- a/DiscImageCreator/execScsiCmd.cpp
+++ b/DiscImageCreator/execScsiCmd.cpp
@@ -668,13 +668,14 @@ BOOL GetConfiguration(
 		pDisc->SCSI.wCurrentMedia = ProfileCdrom;
 		// not false. because undefined mmc1..
 		OutputDriveNoSupportLog("GET_CONFIGURATION");
-		if (pDevice->byPlxtrDrive == PLXTR_DRIVE_TYPE::PX40TS ||
-			pDevice->byPlxtrDrive == PLXTR_DRIVE_TYPE::PX32TS ||
-			pDevice->byPlxtrDrive == PLXTR_DRIVE_TYPE::PX20TS
-			) {
+		if (pDevice->byPlxtrDrive == PLXTR_DRIVE_TYPE::PX40TS) {
 			pDevice->FEATURE.byCanCDText = TRUE;
 			pDevice->FEATURE.byC2ErrorData = TRUE;
 			OutputLog(standardOut | fileDrive, "But this drive supports to read CDText and C2 Error\n");
+		} else if (pDevice->byPlxtrDrive == PLXTR_DRIVE_TYPE::PX32TS ||
+			pDevice->byPlxtrDrive == PLXTR_DRIVE_TYPE::PX20TS) {
+			pDevice->FEATURE.byC2ErrorData = TRUE;
+			OutputLog(standardOut | fileDrive, "But this drive supports to read C2 Error\n");
 		}
 	}
 	else {


### PR DESCRIPTION
(They do not support this feature)

Currently DIC is not working on 32ts/20ts, I've bisected to DICUI 1.17/DIC 20200604 breaking support.  (Probably this commit)

Haven't tested this changes on my pc that supports SCSI yet (exclusively used with windows 7 and no development tools), but this should work, done building on linux.