### PR TITLE
Fix the timezone of the recording date and time in the directory record

### DIFF
--- a/DiscImageCreator/outputFileSystem.cpp
+++ b/DiscImageCreator/outputFileSystem.cpp
@@ -90,7 +90,7 @@ VOID OutputFsDirectoryRecord(
 		"\t\tExtended Attribute Record Length: %u\n"
 		"\t\t              Location of Extent: %u\n"
 		"\t\t                     Data Length: %u\n"
-		"\t\t         Recording Date and Time: %d-%02u-%02uT%02u:%02u:%02u%+03d:%02d\n"
+		"\t\t         Recording Date and Time: %d-%02u-%02uT%02u:%02u:%02u%c%02d:%02d\n"
 		"\t\t                      File Flags: %u (%" CHARWIDTH "s)\n"
 		"\t\t                  File Unit Size: %u\n"
 		"\t\t             Interleave Gap Size: %u\n"
@@ -98,7 +98,7 @@ VOID OutputFsDirectoryRecord(
 		"\t\t       Length of File Identifier: %u\n"
 		"\t\t                 File Identifier: "
 		, lpBuf[0], lpBuf[1], uiExtentPos, uiDataLen, lpBuf[18] + 1900, lpBuf[19], lpBuf[20]
-		, lpBuf[21], lpBuf[22], lpBuf[23], (CHAR)lpBuf[24] / 4, (CHAR)lpBuf[24] % 4 * 15
+		, lpBuf[21], lpBuf[22], lpBuf[23], (CHAR)lpBuf[24] < 0 ? '-' : '+', abs((CHAR)lpBuf[24]) / 4, abs((CHAR)lpBuf[24]) % 4 * 15
 		, lpBuf[25], str, lpBuf[26], lpBuf[27], vsn, lpBuf[32]);
 	BOOL bSkip = FALSE;
 	for (INT n = 0; n < lpBuf[32]; n++) {


### PR DESCRIPTION
Please note that this work was done on the web, so the build and execution have not been checked.

# Wrong cases
```
Value  Current   Correct  Note
-------------------------------------------------------------------------------------
0xFF   +00:-15   -00:15   Wrong sign and unnecessary sign
0xFE   +00:-30   -00:30   Wrong sign and unnecessary sign
0xFD   +00:-45   -00:45   Wrong sign and unnecessary sign
0xE2   -07:-30   -07:30   Unnecessary sign (An example; occurs with other values too)
```
