### PR TITLE
Add validity checks for unshield file entries

### DIFF
--- a/DiscImageCreator/execScsiCmdforCDCheck.cpp
+++ b/DiscImageCreator/execScsiCmdforCDCheck.cpp
@@ -2221,6 +2221,9 @@ BOOL ReadCDForCheckingExe(
 				}
 				int files = unshield_file_count(u);
 				for (int i = 0; i < files; i++) {
+					if (!unshield_file_is_valid(u, i)) {
+						continue;
+					}
 					const char* name = unshield_file_name(u, i);
 					const char* p = PathFindExtensionA(name);
 					if (!p || *p != '.' || p[1] == '\0') {


### PR DESCRIPTION
This PR adds validity checks for file entries handled by the unshield integration.
Entries with FILE_INVALID, missing name_offset, or missing data_offset are now skipped.

This prevents crashes during the file scan performed by the protection check.
