### PR TITLE
Fix space allocated for file names and paths

### DIFF
--- a/DiscImageCreator/DiscImageCreator.cpp
+++ b/DiscImageCreator/DiscImageCreator.cpp
@@ -42,10 +42,10 @@ BYTE g_aSyncHeader[SYNC_SIZE] = {
 
 // These static variable is set at printAndSetPath().
 static _TCHAR s_szCurrentdir[_MAX_PATH];
-static _TCHAR s_szDrive[_MAX_DRIVE];
-static _TCHAR s_szDir[_MAX_DIR];
-static _TCHAR s_szFname[_MAX_FNAME];
-static _TCHAR s_szExt[_MAX_EXT];
+static _TCHAR s_szDrive[_MAX_DRIVE + 1];
+static _TCHAR s_szDir[_MAX_DIR + 1];
+static _TCHAR s_szFname[_MAX_FNAME + 1];
+static _TCHAR s_szExt[_MAX_EXT + 1];
 
 // These static variable is set at checkArg().
 static UINT s_uiFix = 0;

--- a/DiscImageCreator/get.cpp
+++ b/DiscImageCreator/get.cpp
@@ -63,7 +63,7 @@ BOOL GetHandle(
 BOOL GetDriveOffsetManually(
 	LPINT lpDriveOffset
 ) {
-	_TCHAR aBuf[6] = {};
+	_TCHAR aBuf[6 + 1] = {};
 	OutputString(
 		"This drive doesn't define in driveOffset.txt\n"
 		"Please input drive offset(Samples): ");

--- a/DiscImageCreator/output.cpp
+++ b/DiscImageCreator/output.cpp
@@ -47,10 +47,10 @@ FILE* CreateOrOpenFile(
 	BYTE byMaxTrackNum
 ) {
 	_TCHAR szDstPath[_MAX_PATH] = {};
-	_TCHAR szDrive[_MAX_DRIVE] = {};
-	_TCHAR szDir[_MAX_DIR] = {};
-	_TCHAR szFname[_MAX_FNAME] = {};
-	_TCHAR szExt[_MAX_EXT] = {};
+	_TCHAR szDrive[_MAX_DRIVE + 1] = {};
+	_TCHAR szDir[_MAX_DIR + 1] = {};
+	_TCHAR szFname[_MAX_FNAME + 1] = {};
+	_TCHAR szExt[_MAX_EXT + 1] = {};
 
 	_tsplitpath(pszPath, szDrive, szDir, szFname, szExt);
 	if (pszPlusFname) {
@@ -114,7 +114,7 @@ FILE* OpenProgrammabledFile(
 	LPCTSTR pszFname,
 	LPCTSTR pszMode
 ) {
-	_TCHAR szFullPath[_MAX_PATH] = {};
+	_TCHAR szFullPath[_MAX_PATH + 1] = {};
 	if (!::GetModuleFileName(NULL, szFullPath, SIZE_OF_ARRAY(szFullPath))) {
 		OutputLastErrorNumAndString(_T(__FUNCTION__), __LINE__);
 		return NULL;
@@ -127,7 +127,7 @@ FILE* OpenProgrammabledFile(
 #endif
 	if (p) {
 		p[0] = 0;
-		_TCHAR szFullPathName[_MAX_PATH + _MAX_FNAME] = {};
+		_TCHAR szFullPathName[_MAX_PATH + 1 + _MAX_FNAME + 1] = {};
 #ifdef _WIN32
 		_sntprintf(szFullPathName
 			, SIZE_OF_ARRAY(szFullPathName), _T("%s\\%s"), szFullPath, pszFname);
@@ -137,6 +137,10 @@ FILE* OpenProgrammabledFile(
 #endif
 		szFullPathName[_MAX_PATH + _MAX_FNAME - 1] = 0;
 		fp = _tfopen(szFullPathName, pszMode);
+		if(fp == NULL) {
+			OutputLastErrorNumAndString(_T(__FUNCTION__), __LINE__);
+			return NULL;
+		}
 #ifndef _WIN32
 		if (geteuid() == 0) {
 			uid_t uid; gid_t gid;


### PR DESCRIPTION
Picked on linux with GCC, it's much more strict about missing space.