### PR TITLE
Running on Linux without sudo

### DIFF
--- a/DiscImageCreator/DiscImageCreator.cpp
+++ b/DiscImageCreator/DiscImageCreator.cpp
@@ -33,7 +33,7 @@
 
 #define DEFAULT_REREAD_VAL			(4000)
 #define DEFAULT_CACHE_DELETE_VAL	(1)
-#define DEFAULT_SPTD_TIMEOUT_VAL	(60)
+#define DEFAULT_SPTD_TIMEOUT_VAL	(50000)
 
 BYTE g_aSyncHeader[SYNC_SIZE] = {
 	0x00, 0xff, 0xff, 0xff, 0xff, 0xff,

--- a/DiscImageCreator/execIoctl.cpp
+++ b/DiscImageCreator/execIoctl.cpp
@@ -580,7 +580,7 @@ BOOL ScsiPassThroughDirect(
 			if (!pExtArg->byScanProtectViaFile) {
 				// When semaphore time out occurred, if doesn't execute sleep,
 				// UNIT_ATTENSION errors occurs next ScsiPassThroughDirect executing.
-				UINT milliseconds = 25000;
+				UINT milliseconds = 2500;
 				OutputLog(standardError | fileMainError
 					, "Please wait for %u milliseconds until the device is returned\n", milliseconds);
 				Sleep(milliseconds);

--- a/DiscImageCreator/execScsiCmdforCDCheck.cpp
+++ b/DiscImageCreator/execScsiCmdforCDCheck.cpp
@@ -3017,7 +3017,7 @@ BOOL ExecCheckingByteOrder(
 	LPBYTE pBuf = NULL;
 	LPBYTE lpBuf = NULL;
 	if (!GetAlignedCallocatedBuffer(pDevice, &pBuf,
-		CD_RAW_SECTOR_WITH_C2_294_AND_SUBCODE_SIZE, &lpBuf, _T(__FUNCTION__), __LINE__)) {
+		CD_RAW_SECTOR_WITH_C2_AND_SUBCODE_SIZE, &lpBuf, _T(__FUNCTION__), __LINE__)) {
 		return FALSE;
 	}
 	BYTE lpCmd[CDB12GENERIC_LENGTH] = {};
@@ -3025,7 +3025,7 @@ BOOL ExecCheckingByteOrder(
 
 	BOOL bRet = TRUE;
 	if (!ExecReadCD(pExtArg, pDevice, lpCmd, 0, lpBuf
-		, CD_RAW_SECTOR_WITH_C2_294_AND_SUBCODE_SIZE, _T(__FUNCTION__), __LINE__)) {
+		, CD_RAW_SECTOR_WITH_C2_AND_SUBCODE_SIZE, _T(__FUNCTION__), __LINE__)) {
 		OutputLog(standardError | fileDrive,
 			"This drive doesn't support [OpCode: %#02x, C2flag: %d, SubCode: %x]\n"
 			, lpCmd[0], (lpCmd[9] & 0x6) >> 1, lpCmd[10]);


### PR DESCRIPTION
Not sure if third commit is best way:

Current version is causing read outside of stack later, so either this or
reading less later.  Aka reading 294/296 elements instead of always 296 in loop.

(Not sure which one is better)


Works, but still to figure out:
```
....
CurrentDirectory
        /tmp/DiscImageCreator/build/clang-Debug
WorkingPath
         Argument: test.bin
         FullPath: /tmp/DiscImageCreator/build/clang-Debug/test.bin
            Drive: /
        Directory: tmp/DiscImageCreator/build/clang-Debug/
         Filename: test
        Extension: .bin
StartTime: 2026-06-15T02:34:06+0200
[F:SetDiscSpeed][L:861] GetLastError: 1, Operation not permitted
Please wait for 2500 milliseconds until the device is returned
          Block Size: 4096
       Flagment Size: 4096
       All Block Num: 4194304
      Free Block Num: 3769657
 Available Block Num: 3769657
          I Node Num: 4085563
     Free I Node Num: 4079251
Available I Node Num: 4079251
      File System ID: 580501886170413013
          Mount Flag: 4102
 Max Filename Length: 255
...
```

```
...
No C2 errors
Copying .scm to .img
Set LBA to descramble sector 293379/293379
Descrambling data sector of img: 293379/293379
[F:GetEccEdcCmd][L:595] GetLastError: 2, No such file or directory
 => /tmp/DiscImageCreator/build/clang-Debug/./EccEdc.out
Creating cue and ccd (Track)  1/ 1
Creating bin (Track)  1/ 1
...
```