### PR TITLE
Update redump links

### DIFF
--- a/DiscImageCreator/execScsiCmd.cpp
+++ b/DiscImageCreator/execScsiCmd.cpp
@@ -502,7 +502,7 @@ BOOL ReadTOCText(
 #ifdef TEST_CDTEXT_WITH_UNICODE
 		// Irregular CD-TEXT (Unicode is used)
 		// Taiwan release of Di Gi Charat Fantasy (Soundtrack Arrange CD)
-		// http://forum.redump.org/post/101001/#p101001
+		// https://forum.redump.info/viewtopic.php?p=26448#p26448
 		BYTE buf[] = {
 			0x1e, 0x02, 0x00, 0x00,
 			0x80, 0x00, 0x00, 0x80, 0xb0, 0x65, 0x57, 0x30, 0x44, 0x30, 0xbf, 0x30, 0xa4, 0x30, 0xc8, 0x30, 0x06, 0x57,
@@ -1052,7 +1052,7 @@ BOOL ReadCacheForLgAsus(
 ) {
 	CONST DWORD dwBufSize = F1_BUFFER_SIZE * F1_READ_SECTOR_SIZE;
 	BYTE aBuf[dwBufSize] = {};
-	// http://forum.redump.org/post/72629/#p72629
+	// https://forum.redump.info/viewtopic.php?p=25299#p25299
 	// F1 06 xx xx xx xx yy yy yy yy
 	// xx - address to read
 	// yy - length of data to return

--- a/DiscImageCreator/execScsiCmdforCDCheck.cpp
+++ b/DiscImageCreator/execScsiCmdforCDCheck.cpp
@@ -261,7 +261,7 @@ BOOL ExecSearchingOffset(
 	else {
 		if (*pExecType == swap || IsDataDisc(pDisc) ||
 			pDisc->SCSI.trkType & TRACK_TYPE::pregapAudioWithSyncIn1stTrack) {
-			// http://forum.redump.org/post/81925/#p81925
+			// https://forum.redump.info/viewtopic.php?p=25786#p25786
 			INT nSectorNum = 5;
 			LPBYTE pBuf2 = NULL;
 			LPBYTE lpBuf2 = NULL;
@@ -297,9 +297,9 @@ BOOL ExecSearchingOffset(
 				else {
 					if (pDisc->MAIN.nCombinedOffset > 0) {
 						INT nOverRead = pDisc->MAIN.nCombinedOffset / CD_RAW_SECTOR_SIZE;
-						// [FMT] Sangokushi IV http://forum.redump.org/post/82784/#p82784
-						// [FMT] Lip 3: Lipstick Adventure 3 http://forum.redump.org/post/80180/#p80180
-						// [FMT] Gulf War: Soukouden http://forum.redump.org/topic/16418/addedfmt-5-new-dumps/
+						// [FMT] Sangokushi IV https://forum.redump.info/viewtopic.php?p=25806#p25806
+						// [FMT] Lip 3: Lipstick Adventure 3 https://forum.redump.info/viewtopic.php?p=25750#p25750
+						// [FMT] Gulf War: Soukouden https://forum.redump.info/viewtopic.php?p=39470
 						if (nOverRead > 0) {
 							if (k == 0) {
 								SetAndOutputCDOffset(pExtArg, pDisc, bGetDriveOffset
@@ -2914,9 +2914,9 @@ BOOL ReadCDForCheckingSecuROM(
 
 		// All SecuROM titles http://redump.org/discs/quicksearch/securom/protection/only
 		if ((nRLBA == 3000 || nRLBA == 3001) && nALBA == 299) { // 3001(00:40:01), 299(00:03:74)
-			// Aliens Versus Predator 2 (Disc 1) http://redump.org/disc/35861/
-			// Unreal Tournament 2003 (Disc 1) (Play Disc) http://redump.org/disc/21469/
-			// Unreal Tournament 2004 (Play Disc) http://redump.org/disc/61749/
+			// Aliens Versus Predator 2 (Disc 1) https://redump.info/disc/35861/
+			// Unreal Tournament 2003 (Disc 1) (Play Disc) https://redump.info/disc/21469/
+			// Unreal Tournament 2004 (Play Disc) https://redump.info/disc/61749/
 			OutputSubInfoWithLBALog(
 				"Detected intentional error. CRC-16 is original:[%02x%02x] and XORed with 0x8001:[%02x%02x] "
 				, -1, 0, pDiscPerSector->subcode.current[22] ^ 0x80, pDiscPerSector->subcode.current[23] ^ 0x01
@@ -2939,13 +2939,13 @@ BOOL ReadCDForCheckingSecuROM(
 				, pDiscPerSector->subcode.current[19], pDiscPerSector->subcode.current[20], pDiscPerSector->subcode.current[21]);
 
 			if (nRLBA == 167295) {
-				// Colin McRae Rally 2.0 (Europe) http://redump.org/disc/31587/
+				// Colin McRae Rally 2.0 (Europe) https://redump.info/disc/31587/
 				OutputLog(standardOut | fileDisc, "Detected intentional subchannel in LBA -1 => SecuROM 3rd version type 1 (a.k.a. NEW)\n");
 				pDisc->PROTECT.byExist = securomV3_1;
 			}
 			else if (nRLBA == 0) {
-				// Empire Earth (USA) http://redump.org/disc/45559/
-				// Diablo II: Lord of Destruction (Expansion Set) (USA) http://redump.org/disc/58232/
+				// Empire Earth (USA) https://redump.info/disc/45559/
+				// Diablo II: Lord of Destruction (Expansion Set) (USA) https://redump.info/disc/58232/
 				OutputLog(standardOut | fileDisc, "Detected intentional subchannel in LBA -1 => SecuROM 3rd version type 2 (a.k.a. NEW)\n");
 				pDisc->PROTECT.byExist = securomV3_2;
 			}
@@ -2982,7 +2982,7 @@ BOOL ReadCDForCheckingSecuROM(
 				, BcdToDec(pDiscPerSector->subcode.current[20]), BcdToDec(pDiscPerSector->subcode.current[21]));
 
 			if (nRLBA == 5001 && nALBA == 5151) { // 5001(01:06:51), 5151(01:08:51)
-				// Supreme Snowboarding (Europe) http://redump.org/disc/32182/
+				// Supreme Snowboarding (Europe) https://redump.info/disc/32182/
 				OutputLog(standardOut | fileDisc, "Detected intentional subchannel in LBA 5000 => SecuROM 2nd version (a.k.a. NEW)\n");
 				pDisc->PROTECT.byExist = securomV2;
 			}
@@ -2998,7 +2998,7 @@ BOOL ReadCDForCheckingSecuROM(
 						WORD reCalcXorCrc16 = (WORD)(reCalcCrc16 ^ 0x0080);
 						if (pDiscPerSector->subcode.current[22] == HIBYTE(reCalcXorCrc16) &&
 							pDiscPerSector->subcode.current[23] == LOBYTE(reCalcXorCrc16)) {
-							// FIFA 99 (Europe) http://redump.org/disc/23791/
+							// FIFA 99 (Europe) https://redump.info/disc/23791/
 							OutputLog(standardOut | fileDisc
 								, "Detected intentional subchannel in LBA %d => SecuROM 1st version (a.k.a. OLD)\n", nTmpLBA);
 							pDisc->PROTECT.byExist = securomV1;

--- a/DiscImageCreator/execScsiCmdforFileSystem.cpp
+++ b/DiscImageCreator/execScsiCmdforFileSystem.cpp
@@ -163,7 +163,7 @@ BOOL IsValidExtent(
 	return FALSE;
 }
 
-// http://forum.redump.org/post/101790/#p101790
+// https://forum.redump.info/viewtopic.php?p=26462#p26462
 //#define TBL_TEST
 BOOL ReadDirectoryRecordDetail(
 	PEXEC_TYPE pExecType,
@@ -220,9 +220,9 @@ BOOL ReadDirectoryRecordDetail(
 			if (lpDirRec[0] >= MIN_LEN_DR) {
 #if 0
 				// Due to this code, other disc can't dump.
-				// http://forum.redump.org/post/81822/#p81822
+				// https://forum.redump.info/viewtopic.php?p=25785#p25785
 				if (lpDirRec[0] == MIN_LEN_DR && uiOfs > 0 && uiOfs % DISC_MAIN_DATA_SIZE == 0) {
-					// http://forum.redump.org/post/56490/#p56490
+					// https://forum.redump.info/viewtopic.php?p=24342#p24342
 					// [PC] SimCity 3000 (USA)
 					// Data Length should be 2048 because LBA 200205 is joliet
 					// ========== LBA[200204, 0x30e0c]: Directory Record ==========
@@ -901,9 +901,9 @@ BOOL ReadCDForFileSystem(
 				if (!ExecReadCD(pExtArg, pDevice, (LPBYTE)&cdb, nLBA, lpBuf,
 					DISC_MAIN_DATA_SIZE, _T(__FUNCTION__), __LINE__)) {
 					// some disc occur VENDOR UNIQUE ERROR
-					// http://forum.redump.org/post/101367/#p101367
+					// https://forum.redump.info/viewtopic.php?p=26454#p26454
 					// [FMT] Rainbow Islands: The Story of Bubble Bobble 2: Extra Version
-					// http://redump.org/disc/74148/
+					// https://redump.info/disc/74148/
 					throw TRUE;
 				}
 				// for MAC pattern 1

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   [MPF](https://github.com/SabreTools/MPF) can work this program with GUI.
 
 ## Bug report
- To: http://forum.redump.org/topic/10483/discimagecreator/  
+ To: https://forum.redump.info/viewtopic.php?t=7568
   or  
  To: https://github.com/saramibreak/DiscImageCreator/issues
 
@@ -35,7 +35,7 @@
    - ASUS
      - BC-12D2HT (Combined offset minus disc only), BW-16D1HT (ditto)
        - BW-16D1HT Firmware 3.02 supports the combined offset plus disc  
-       See also http://wiki.redump.org/index.php?title=Optical_Disc_Drive_Compatibility#Non-Plextor_ODDs_.28Plextors_are_preferable.2C_as_more_testing_is_needed_for_these.29
+       See also https://wiki.redump.info/Optical_Disc_Drives:_CD_Compatibility_Technical_Details#MediaTek_Blu-ray_Drives
    - Hitachi-LG
      - UH12NS30 (Combined offset minus disc only)
 - CD: (Swappable drive) (This is the comfirmed drive list. Actually, many drive perhaps supports to swap)
@@ -46,7 +46,7 @@
 - GD:
    - TSSTcorp
      - TS-H353A, TS-H352C, TS-H192C
-     - http://forum.redump.org/post/14552/#p14552 <- This drive might be supported too.
+     - https://forum.redump.info/viewtopic.php?p=3524#p3524 <- This drive might be supported too.
 - DVD: All supported drive
 - DVD (Raw): 
      - PLEXTOR (No OEM Drive)
@@ -55,7 +55,7 @@
        - LH-18A1P
      - ASUS/LG
        - BW-16D1HT, BC-12D2HT etc. (Firmware 3.02 is needed.)
-       See also http://wiki.redump.org/index.php?title=Optical_Disc_Drive_Compatibility#Non-Plextor_ODDs_.28Plextors_are_preferable.2C_as_more_testing_is_needed_for_these.29
+       See also https://wiki.redump.info/Optical_Disc_Drives:_CD_Compatibility_Technical_Details#MediaTek_Blu-ray_Drives
      - Other
        - See "DVDRawBruteforce - Drive Sheet - Sheet1.tsv" in the Release_ANSI folder
 - GC/Wii
@@ -197,7 +197,7 @@ See [wiki](https://github.com/saramibreak/DiscImageCreator/wiki)
      => These needs DPM(Data position measurement). cue, ccd doesn't support DPM.
         You need to use the [Alcohol 120/52%](http://www.alcohol-soft.com/) to store it, 
   - Alpha-ROM, ROOT, TAGES [duplicated(double, triple) sector]  
-     => It can read in reverse, but specifications are not decided in redump.org
+     => It can read in reverse, but specifications are not decided in redump
 
   Nintendo Wii U
    => This is a BD based disc, but I don't know the details.
@@ -371,4 +371,4 @@ See LICENSE
  Trouble in regard to the use of this tool, I can not guarantee any.
 
 ## Gratitude
- Thank's redump.org users.
+ Thank's redump users.

--- a/Release_ANSI/Doc/KnownIssue.txt
+++ b/Release_ANSI/Doc/KnownIssue.txt
@@ -17,8 +17,8 @@
 
 . can't get a drive name when use a part of IDE to USB adapter.
 
-. Plextor sometimes shifts some bytes when dumps the disc. http://forum.redump.org/post/91259/#p91259
+. Plextor sometimes shifts some bytes when dumps the disc. https://forum.redump.info/viewtopic.php?p=26118#p26118
 
-. C2 error pointer is not perfect. http://forum.redump.org/post/90835/#p90835
+. C2 error pointer is not perfect. https://forum.redump.info/viewtopic.php?p=26105#p26105
 
-. can not capture the console correctly. http://forum.redump.org/post/90764/#p90764
+. can not capture the console correctly. https://forum.redump.info/viewtopic.php?p=26096#p26096

--- a/Release_ANSI/Doc/Todo.txt
+++ b/Release_ANSI/Doc/Todo.txt
@@ -1,25 +1,25 @@
 ==================================== TODO =====================================
 [unintentioanl behavior (or bug)]
-. failed to read of LBA 16 http://forum.redump.org/post/94542/#p94542
-. the shifted offset be explained by ASUS drive or a Linux bug? http://forum.redump.org/post/90412/#p90412 http://forum.redump.org/post/93955/#p93955
-. The C2 errors are completely random and inconsistent Scooby-Doo! 2.0.0 for the iXL http://forum.redump.org/post/89722/#p89722 http://forum.redump.org/post/90011/#p90011
-. failed to read Directory Record of some XBOX discs http://forum.redump.org/post/97640/#p97640
-. PS2 unlicenced disc doesn't match the hash http://forum.redump.org/post/96246/#p96246 http://forum.redump.org/post/97804/#p97804
+. failed to read of LBA 16 https://forum.redump.info/viewtopic.php?p=26223#p26223
+. the shifted offset be explained by ASUS drive or a Linux bug? https://forum.redump.info/viewtopic.php?p=26083#p26083 https://forum.redump.info/viewtopic.php?p=26178#p26178
+. The C2 errors are completely random and inconsistent Scooby-Doo! 2.0.0 for the iXL https://forum.redump.info/viewtopic.php?p=26049#p26049 https://forum.redump.info/viewtopic.php?p=26062#p26062
+. failed to read Directory Record of some XBOX discs https://forum.redump.info/viewtopic.php?p=26364#p26364
+. PS2 unlicenced disc doesn't match the hash https://forum.redump.info/viewtopic.php?p=26314#p26314 https://forum.redump.info/viewtopic.php?p=26367#p26367
 
 [protection]
-. support DiscGuard http://forum.redump.org/post/94457/#p94457
+. support DiscGuard https://forum.redump.info/viewtopic.php?p=26217#p26217
 . support twin sector disc (for ALPHA-ROM, ROOT, TAGES)
-. support SafeDisc on DVD http://forum.redump.org/post/87385/#p87385
+. support SafeDisc on DVD https://forum.redump.info/viewtopic.php?p=26012#p26012
 
 [image]
 . support mdf/mds (for SecuROM v4.x or higher, StarForce, CD-Cops)
 . support cue file of sub-pchannel version
 
 [main]
-. support generating ecc/edc when unreadable sectors are generated http://forum.redump.org/post/93774/#p93774
+. support generating ecc/edc when unreadable sectors are generated https://forum.redump.info/viewtopic.php?p=26173#p26173
 
-. LBA 2174 has 2352+16 bytes? Due to this sector LBA 2175 ... last are all shifted. http://forum.redump.org/post/92408/#p92408
-. LBA 950 ... last are all shifted because LBA 949 is mastering error (2352 + 120 bytes) http://forum.redump.org/post/92507/#p92507
+. LBA 2174 has 2352+16 bytes? Due to this sector LBA 2175 ... last are all shifted. https://forum.redump.info/viewtopic.php?p=26141#p26141
+. LBA 950 ... last are all shifted because LBA 949 is mastering error (2352 + 120 bytes) https://forum.redump.info/viewtopic.php?p=26147#p26147
 
 [sub]
 . check parity P, Q for CD+G
@@ -88,7 +88,7 @@
       So, I can use these documents and source codes as reference, but I don't understand these yet.
 
 . sub fixing algo
-  http://forum.redump.org/post/61192/#p61192
+  https://forum.redump.info/viewtopic.php?p=24597#p24597
   1. You define 9 variables: SubRereadNum, CurrentSubReadNum, CurrentSectorNum, FixLevel, QCurrentSector, QNextSector, QGenSector, QEAN, QISRC.
   2. From commandline args you read FixLevel (should be between 0 and 96) and SubRereadNum (0 or larger)
   3. You read a sector with the LBA = CurrentSectorNum (0 by default) and put its Q-channel into QCurrentSector.
@@ -108,7 +108,7 @@
   5.4. If Q-CRC is good and QCurrentSector mode = 0x03 (ISRC): QISRC = QCurrentSector and QNextSector = QNextSector + 1 frame
   5.5. CurrentSectorNum = CurrentSectorNum + 1, CurrentSubReadNum = 0
 
-  http://forum.redump.org/post/61203/#p61203
+  https://forum.redump.info/viewtopic.php?p=24600#p24600
   For each of the P, R, S, T, U, V, W channels you just need to detect the padding byte for the current sector
   (if more than 6 bytes are 0x00 - the padding byte is 0x00, if more than 6 bytes are 0xFF - the padding byte is 0xFF), 
   then do a bit compare of the current sector against 000000000000000000000000 or FFFFFFFFFFFFFFFFFFFFFFFF or any other variant, if exists.
@@ -134,7 +134,7 @@
    => I know Lite-on drive reads lead-out (about 6750 sectors - 01:30:00)
 
 . search the offsets precisely
-  http://forum.redump.org/post/56707/#p56707
+  https://forum.redump.info/viewtopic.php?p=39485#p39485
   [quote]
   1.search sync. (IsValidMainDataHeader) "i" is 0x6c(108)
   2.get msf. (BcdToDec) "sm" is 0, "ss" is 01, "sf" is 70


### PR DESCRIPTION
Redump is moving to redump.info due to redump.org being slow and sometimes having long downtime over days/weeks (and no https). 
Redump links in DIC need updating.

This is the new link to DIC thread, you can use it in the github about section: 
<img width="232" height="165" alt="image" src="https://github.com/user-attachments/assets/ff8b8214-58d6-400b-8a30-92a51194f7c9" />

https://forum.redump.info/viewtopic.php?t=7568

P.S. press "[I forgot my password](https://forum.redump.info/app.php/user/forgot_password)" to recover your account on the new site (assuming you have access to your redump email.