### PR TITLE
Fix Linux fd (floppy) SIGSEGV and allow dumping write-protected media

### DIFF
--- a/DiscImageCreator/_linux/defineForLinux.cpp
+++ b/DiscImageCreator/_linux/defineForLinux.cpp
@@ -623,6 +623,15 @@ int DeviceIoControl(int fd, unsigned long ioCtlCode, void* inbuf, unsigned long 
 	UNREFERENCED_PARAMETER(d);
 	UNREFERENCED_PARAMETER(e);
 	PSCSI_PASS_THROUGH_DIRECT_WITH_BUFFER p = (PSCSI_PASS_THROUGH_DIRECT_WITH_BUFFER)inbuf;
+	if (p == NULL) {
+		// This Linux shim only implements the SCSI pass-through path, which
+		// requires a PSCSI_PASS_THROUGH_DIRECT_WITH_BUFFER input buffer.
+		// Callers that pass no buffer (e.g. the disk-geometry ioctls used by
+		// DiskGetMediaTypes for floppy media) would otherwise dereference NULL
+		// and crash; report failure instead.
+		SetLastError(EINVAL);
+		return FALSE;
+	}
 	int ret = ioctl(fd, ioCtlCode, &(p->io_hdr));
 	memcpy(&(p->SenseData), p->Dummy, 18);
 	ret = ret != -1 ? TRUE : FALSE;

--- a/DiscImageCreator/get.cpp
+++ b/DiscImageCreator/get.cpp
@@ -50,6 +50,12 @@ BOOL GetHandle(
 #elif defined(__linux__)
 	pDevice->hDevice = open(pDevice->drivepath, O_RDWR | O_EXCL | O_NONBLOCK, 0777);
 	if (pDevice->hDevice == -1) {
+		// Write-protected / read-only media (e.g. a write-protected floppy)
+		// rejects O_RDWR with EROFS. Dumping only needs read access, so fall
+		// back to read-only; setDiscSpeed (which needs write) is then skipped.
+		pDevice->hDevice = open(pDevice->drivepath, O_RDONLY | O_EXCL | O_NONBLOCK, 0777);
+	}
+	if (pDevice->hDevice == -1) {
 #elif defined(__APPLE__) && defined(__MACH__)
 	pDevice->hDevice = GetSCSITaskInterface(pDevice->drivepath);
 	if (pDevice->hDevice == NULL) {


### PR DESCRIPTION
### Summary

Two fixes for dumping a floppy (`fd`) on Linux, both found while dumping a real USB floppy on Fedora 43.

**1. SIGSEGV on every `fd` dump (fixes #327)**

`DiskGetMediaTypes()` calls the Linux `DeviceIoControl` shim with a NULL input buffer for the disk-geometry ioctls. The shim casts the input buffer to `PSCSI_PASS_THROUGH_DIRECT_WITH_BUFFER` and dereferences it unconditionally (`memcpy(&p->SenseData, p->Dummy, 18)`), so it crashes whenever the buffer is NULL.

Backtrace (master `e5771e8`, built with `DEBUG=1`):

```
#0  __memmove_...           (libc)
#1  DeviceIoControl (fd=4, ioCtlCode=8837, inbuf=0x0, ...) at _linux/defineForLinux.cpp:627
#2  DiskGetMediaTypes (...) at execIoctl.cpp:32
#3  ReadDisk (...)          at execIoctl.cpp:415
#4  execForDumping / exec / main
```

This commit returns `FALSE`/`EINVAL` when no pass-through buffer is supplied instead of dereferencing NULL.

**2. Write-protected media can't be opened**

`GetHandle()` opens the device `O_RDWR`, so a write-protected floppy (or any read-only medium) fails at `open()` with `EROFS` before any dump can start. Since dumping only needs read access, this commit falls back to a read-only open when the read-write open fails; `setDiscSpeed` (which needs write) is then simply skipped.

### Testing

Built from master (`e5771e8`) on Fedora 43 x86_64 and run against a NEC USB floppy (`/dev/sdh`, USB ID `0409:0040`, UFI) with a write-protected 1.44 MB disk:

- Before: `open()` fails with `EROFS` on the write-protected disk; on a writable disk it reads the drive and then SIGSEGVs.
- After both fixes: the device opens read-only, the drive is read (the `*_drive.txt` log is written in full), and the command exits cleanly instead of crashing.

Note: this does not yet make floppy dumping fully work on Linux — the shim still doesn't implement the disk-geometry ioctls (`IOCTL_DISK_GET_MEDIA_TYPES` / `IOCTL_DISK_GET_DRIVE_GEOMETRY`), so `DiskGetMediaTypes()` now returns a clean error instead of crashing. Implementing those via the Linux block ioctls (`BLKGETSIZE64` / `BLKSSZGET`) would be a sensible follow-up.

---
*Prepared with AI assistance (Claude Opus 4.8) and reviewed before submission.*
