### PR TITLE
Select the drive that was actually requested on macOS

### DIFF
--- a/DiscImageCreator/_linux/defineForLinux.cpp
+++ b/DiscImageCreator/_linux/defineForLinux.cpp
@@ -665,12 +665,76 @@ IOCFPlugInInterface** plugInInterface;
 MMCDeviceInterface** mmcInterface;
 SCSITaskDeviceInterface** interface;
 
+// Copies an IOKit string property, without the padding spaces it is stored with.
+void CopyTrimmedProperty(CFStringRef src, char* dst, size_t dstSize)
+{
+	dst[0] = 0;
+	if (!src || CFGetTypeID(src) != CFStringGetTypeID()
+		|| !CFStringGetCString(src, dst, (CFIndex)dstSize, kCFStringEncodingUTF8)) {
+		return;
+	}
+	size_t len = strlen(dst);
+	while (len > 0 && isspace((unsigned char)dst[len - 1])) {
+		dst[--len] = 0;
+	}
+}
+
+// The BSD name ("disk4") is not a property of the SCSI peripheral device. It belongs to the
+// IOMedia object that the block storage stack publishes below it, so it has to be searched
+// for recursively - and it only exists while a disc is loaded.
+void GetDriveBSDName(io_service_t service, char* dst, size_t dstSize)
+{
+	CFStringRef name = (CFStringRef)IORegistryEntrySearchCFProperty(service, kIOServicePlane
+		, CFSTR(kIOBSDNameKey), kCFAllocatorDefault, kIORegistryIterateRecursively);
+	CopyTrimmedProperty(name, dst, dstSize);
+	if (name) {
+		CFRelease(name);
+	}
+}
+
+// Vendor and product of the drive itself ("PLEXTOR DVDR   PX-760A"). Unlike the BSD name
+// this is there whether or not a disc is loaded, so it can also name an empty drive.
+void GetDriveName(io_service_t service, char* dst, size_t dstSize)
+{
+	dst[0] = 0;
+	CFDictionaryRef characteristics = (CFDictionaryRef)IORegistryEntrySearchCFProperty(
+		service, kIOServicePlane, CFSTR(kIOPropertyDeviceCharacteristicsKey)
+		, kCFAllocatorDefault, kIORegistryIterateRecursively | kIORegistryIterateParents);
+	if (!characteristics) {
+		return;
+	}
+	if (CFGetTypeID(characteristics) == CFDictionaryGetTypeID()) {
+		char vendor[16] = {};
+		char product[64] = {};
+		CopyTrimmedProperty((CFStringRef)CFDictionaryGetValue(
+			characteristics, CFSTR(kIOPropertyVendorNameKey)), vendor, sizeof(vendor));
+		CopyTrimmedProperty((CFStringRef)CFDictionaryGetValue(
+			characteristics, CFSTR(kIOPropertyProductNameKey)), product, sizeof(product));
+		// ATA drives report no vendor, everything is in the product name.
+		snprintf(dst, dstSize, "%s%s%s", vendor, vendor[0] && product[0] ? " " : "", product);
+	}
+	CFRelease(characteristics);
+}
+
+void OutputAvailableDrives(PAUTHORING_DEVICE pDevices, int nDeviceNum)
+{
+	if (nDeviceNum == 0) {
+		fprintf(stderr, "No drive supports SCSITaskAuthoringDevice\n");
+		return;
+	}
+	fprintf(stderr, "Available drive:\n");
+	for (int i = 0; i < nDeviceNum; i++) {
+		fprintf(stderr, "\t%-9s %s\n"
+			, pDevices[i].bsdName[0] ? pDevices[i].bsdName : "(no disc)", pDevices[i].driveName);
+	}
+}
+
 SCSITaskInterface** GetSCSITaskInterface(char* path)
 {
-	const char* bsdName = path;
+	const char* requested = path;
 	const char* slash = strrchr(path, '/');
 	if (slash) {
-		bsdName = slash + 1;   // "/dev/disk2" -> "disk2"
+		requested = slash + 1;   // "/dev/disk2" -> "disk2"
 	}
 	// Create the dictionaries
 	CFMutableDictionaryRef matchingDict = CFDictionaryCreateMutable(
@@ -694,36 +758,72 @@ SCSITaskInterface** GetSCSITaskInterface(char* path)
 		fprintf(stderr, "IOServiceGetMatchingServices failed: 0x%x\n", err);
 		return NULL;
 	}
-	io_service_t service = IO_OBJECT_NULL;
+	// The matching dictionary already asked for SCSITaskAuthoringDevice, so everything the
+	// iterator returns is one. Collect them all: the requested drive has to be picked out of
+	// them, and if it is not among them the others are worth reporting.
+	AUTHORING_DEVICE devices[MAX_AUTHORING_DEVICE_NUM] = {};
+	int nDeviceNum = 0;
 	io_service_t tmp;
 	while ((tmp = IOIteratorNext(iterator))) {
-		io_name_t service_class = "";
-		io_string_t service_path = "";
-		IORegistryEntryGetPath(tmp, kIOServicePlane, service_path);
-		IOObjectGetClass(tmp, service_class);
-
-		CFStringRef cat = (CFStringRef)IORegistryEntryCreateCFProperty(
-			tmp, CFSTR(kIOPropertySCSITaskDeviceCategory), kCFAllocatorDefault, 0);
-		if (cat) {
-			char buf[128];
-			if (CFStringGetCString(cat, buf, sizeof(buf), kCFStringEncodingUTF8)) {
-				if (strcmp(buf, kIOPropertySCSITaskAuthoringDevice) == 0) {
-					printf("Class: %s\nPath: %s\n", service_class, service_path);
-					service = tmp;
-					CFRelease(cat);
-					break;
-				}
-			}
-			CFRelease(cat);
+		if (nDeviceNum == MAX_AUTHORING_DEVICE_NUM) {
+			IOObjectRelease(tmp);
+			continue;
 		}
-
-		IOObjectRelease(tmp);
+		devices[nDeviceNum].service = tmp;
+		GetDriveBSDName(tmp, devices[nDeviceNum].bsdName, sizeof(devices[nDeviceNum].bsdName));
+		GetDriveName(tmp, devices[nDeviceNum].driveName, sizeof(devices[nDeviceNum].driveName));
+		nDeviceNum++;
 	}
 	IOObjectRelease(iterator);
-	if (!service) {
-		fprintf(stderr, "Not found SCSITaskAuthoringDevice\n");
+
+	// A loaded disc gives the drive a BSD name, which is unambiguous. Prefer it.
+	int nSelected = -1;
+	for (int i = 0; i < nDeviceNum; i++) {
+		if (devices[i].bsdName[0] && strcmp(devices[i].bsdName, requested) == 0) {
+			nSelected = i;
+			break;
+		}
+	}
+	// An empty drive has no BSD name, so eject/close/start/stop would have nothing to
+	// address it by. Match on the drive name for those, and refuse if it is not unique.
+	if (nSelected == -1) {
+		int nMatchNum = 0;
+		for (int i = 0; i < nDeviceNum; i++) {
+			if (devices[i].driveName[0] && strcasestr(devices[i].driveName, requested)) {
+				nSelected = i;
+				nMatchNum++;
+			}
+		}
+		if (nMatchNum > 1) {
+			fprintf(stderr, "Ambiguous drive: %s\n", requested);
+			OutputAvailableDrives(devices, nDeviceNum);
+			for (int i = 0; i < nDeviceNum; i++) {
+				IOObjectRelease(devices[i].service);
+			}
+			return NULL;
+		}
+	}
+	if (nSelected == -1) {
+		fprintf(stderr, "Not found the drive: %s\n", requested);
+		OutputAvailableDrives(devices, nDeviceNum);
+		for (int i = 0; i < nDeviceNum; i++) {
+			IOObjectRelease(devices[i].service);
+		}
 		return NULL;
 	}
+
+	io_service_t service = devices[nSelected].service;
+	for (int i = 0; i < nDeviceNum; i++) {
+		if (i != nSelected) {
+			IOObjectRelease(devices[i].service);
+		}
+	}
+	io_name_t service_class = "";
+	io_string_t service_path = "";
+	IOObjectGetClass(service, service_class);
+	IORegistryEntryGetPath(service, kIOServicePlane, service_path);
+	printf("Class: %s\nPath: %s\n", service_class, service_path);
+
 	CFTypeRef prop = IORegistryEntryCreateCFProperty(service, CFSTR("IOCFPlugInTypes"), kCFAllocatorDefault, 0);
 	if (!prop) {
 	    fprintf(stderr, "Not found IOCFPlugInTypes\n");
@@ -733,12 +833,16 @@ SCSITaskInterface** GetSCSITaskInterface(char* path)
 	    CFRelease(prop);
 	}
 
-	char unmountCmd[256];
-	snprintf(unmountCmd, sizeof(unmountCmd),
-		"diskutil unmountDisk %s > /dev/null", bsdName);
-	printf("unmountCmd: %s\n", unmountCmd);
-	if (system(unmountCmd) != 0) {
-		fprintf(stderr, "Failed: system(unmountDisk)\n");
+	// Unmount the drive that is about to be opened. There is nothing to unmount when it
+	// holds no disc, and ObtainExclusiveAccess fails on a drive that is still mounted.
+	if (devices[nSelected].bsdName[0]) {
+		char unmountCmd[256];
+		snprintf(unmountCmd, sizeof(unmountCmd),
+			"diskutil unmountDisk %s > /dev/null", devices[nSelected].bsdName);
+		printf("unmountCmd: %s\n", unmountCmd);
+		if (system(unmountCmd) != 0) {
+			fprintf(stderr, "Failed: system(unmountDisk)\n");
+		}
 	}
 
 	SInt32        score;

--- a/DiscImageCreator/_linux/defineForLinux.h
+++ b/DiscImageCreator/_linux/defineForLinux.h
@@ -2252,6 +2252,7 @@ typedef struct _AACS_READ_BINDING_NONCE {
 #include <IOKit/IOBSD.h>
 #include <IOKit/IOKitLib.h>
 #include <IOKit/scsi/SCSITaskLib.h>
+#include <IOKit/storage/IOStorageDeviceCharacteristics.h>
 #define ENUM_DYLD_BOOL 1
 #include <mach-o/dyld.h>
 #endif
@@ -2498,6 +2499,22 @@ off_t SetFilePointer(int fd, off_t pos, void* a, int origin);
 
 off64_t SetFilePointerEx(int fd, LARGE_INTEGER pos, void* a, int origin);
 #elif defined(__APPLE__) && defined(__MACH__)
+#define MAX_AUTHORING_DEVICE_NUM	16
+
+typedef struct _AUTHORING_DEVICE {
+	io_service_t service;
+	char bsdName[16];    // "disk4". Empty while the drive holds no disc.
+	char driveName[80];  // "PLEXTOR DVDR   PX-760A". There with or without a disc.
+} AUTHORING_DEVICE, *PAUTHORING_DEVICE;
+
+void CopyTrimmedProperty(CFStringRef src, char* dst, size_t dstSize);
+
+void GetDriveBSDName(io_service_t service, char* dst, size_t dstSize);
+
+void GetDriveName(io_service_t service, char* dst, size_t dstSize);
+
+void OutputAvailableDrives(PAUTHORING_DEVICE pDevices, int nDeviceNum);
+
 SCSITaskInterface** GetSCSITaskInterface(char* path);
 
 int CloseHandle(SCSITaskInterface** task);


### PR DESCRIPTION
On macOS, `GetSCSITaskInterface()` (`_linux/defineForLinux.cpp`) derives the BSD name from the drive argument but never compares it against anything. The loop takes the first `SCSITaskAuthoringDevice` IOKit hands out and breaks; the name is then used only for the `diskutil unmountDisk` call further down. DiscImageCreator unmounts the drive that was asked for and opens whichever drive happened to be enumerated first.

The other platforms cannot do this. `GetHandle()` opens the named device directly - `CreateFile("\\\\.\\%c:")` on Windows, `open(pDevice->drivepath)` on Linux - so the drive that was named is the drive that is used, and when it cannot be used the run fails on *that* drive. Only the macOS path enumerates, and it enumerates without looking at the name.

### The argument is unused, not merely mismatched

A drive name that exists nowhere on the machine:

```
Linux   $ DiscImageCreator cd /dev/sr9 out.bin 8
        [F:GetHandle][L:63] GetLastError: 2, No such file or directory

macOS   $ DiscImageCreator cd disk99 out.bin 8
        Class: IODVDServices
        Path: IOService:/AppleACPIPlatformExpert/PCI0/AppleACPIPCI/SEF@1D,7/SEF@fd000000/
              AppleUSBEHCIPort@fd100000/External USB Storage Device@fd100000/...
        unmountCmd: diskutil unmountDisk disk99 > /dev/null
```

Linux fails on the drive it was given. macOS opens a different one - here the USB Plextor.

### What that costs

The test machine has two optical drives:

| BSD name | drive | disc | `SCSITaskAuthoringDevice` |
|---|---|---|---|
| `disk1` | QEMU DVD-ROM (emulated) | ISO `MPFTEST`, 8.8 MB, one data track | no |
| `disk4` | PLEXTOR DVDR PX-760A (USB) | `PhotoCD Portfolio`, 310.6 MB, data + audio track | yes |

Asking for `disk1` on current `master` unmounts `disk1`, opens the Plextor, and then runs with no error and no warning. The files named after `disk1` describe a disc that is not in `disk1`:

```
asked-for-disk1_drive.txt:   VendorId: PLEXTOR
                             ProductId: DVDR   PX-760A
                             ProductRevisionLevel: 1.07

asked-for-disk1.toc:          Data Track  1, LBA     0 -  28051, Length  28052
                             Audio Track  2, LBA 28052 - 132072, Length 104021
```

That is the mixed-mode PhotoCD sitting in `disk4`. The disc in `disk1` is a single 8.8 MB data track.

When the wrongly opened drive still holds a mounted volume the failure is loud but misleading instead: `ObtainExclusiveAccess` returns `e00002d5` (`kIOReturnBusy`) and the run aborts with `GetLastError: 2, No such file or directory`, because the unmount went to the drive that was *not* opened. A disc macOS cannot mount - audio, console, damaged - is never mounted, so in that case nothing stops the wrong dump.

### This does not make an unsupported drive dumpable

`disk1` is an emulated drive that macOS does not publish as a `SCSITaskAuthoringDevice`. It cannot be dumped, and it should not be. The problem is what happens instead of saying so. After this change DiscImageCreator does say so, and shows what is there:

```
$ DiscImageCreator start disk1
Not found the drive: disk1
Available drive:
        disk4     PLEXTOR DVDR   PX-760A
```

Which drives are supported and how they are dumped is untouched. Only the choice of which IOKit service gets opened changes.

### Change

Collect the authoring devices and pick the requested one out of them, by BSD name when a disc is loaded and by drive name otherwise.

The BSD name is not a property of the SCSI peripheral device. It belongs to the `IOMedia` object that the block storage stack publishes below it, so it is searched for with `IORegistryEntrySearchCFProperty()` and `kIORegistryIterateRecursively` rather than read from the device node. This is the same lookup redumper uses on macOS.

macOS assigns that name only while a disc is loaded, so it cannot address an empty drive - and `eject`, `close`, `start` and `stop` need exactly that. Vendor and product from the device characteristics are there with or without a disc, so they serve as the name in that case (`PX-760A`, `PLEXTOR`, case insensitive). A name that fits more than one drive is refused rather than guessed.

`diskutil unmountDisk` now runs on the drive that is about to be opened rather than on the string that was passed in, and is skipped when that drive holds no disc.

### Before / after

| requested | before | after |
|---|---|---|
| `disk1` | opens `disk4` (Plextor) | `Not found the drive: disk1`, lists `disk4` |
| `disk99` | opens `disk4` (Plextor) | `Not found the drive: disk99`, lists `disk4` |
| `disk4` | opens `disk4` | opens `disk4`, dump runs (`VendorId: PLEXTOR`, TOC and disc info read) |
| `PX-760A` | opens `disk4` by luck | opens `disk4` |
| `plextor` | opens `disk4` by luck | opens `disk4` |

With the disc ejected, so the drive has no BSD name at all:

| requested | after |
|---|---|
| `disk4` | `Not found the drive: disk4`, lists `(no disc)  PLEXTOR DVDR   PX-760A` |
| `PX-760A` | opens the drive, `close` closes the tray |

### Testing

macOS 26.5.2, x86_64, built with meson/ninja and Homebrew `libarchive` + `openssl@3`. Real USB PLEXTOR PX-760A with a mixed-mode disc, plus a second optical drive that is not an authoring device. Every row of both tables above was run on that machine, and a full `cd` dump still reads the disc through the new selection.

The machine has only one authoring device, so the case of two of them - where the first one enumerated wins and the second is unreachable - is not something I was able to run. What is shown above is the same defect from the other side: the name is never compared, so any name lands on the same drive.

Compiler warnings are unchanged (71 before, 71 after, `-Wall -Wextra`). The patched tree also builds on Linux (Fedora, 0 warnings); only the `__APPLE__` branch is touched, so Linux and Windows are unaffected.

---
*Prepared with AI assistance (Claude Opus 4.8) and reviewed before submission.*
