### PR TITLE
Fix build on aarch64 (64-bit pointer typedefs)

### DIFF
--- a/DiscImageCreator/_linux/defineForLinux.h
+++ b/DiscImageCreator/_linux/defineForLinux.h
@@ -13,7 +13,7 @@ typedef unsigned short      UINT16, *PUINT16;
 typedef unsigned int        UINT32, *PUINT32;
 typedef unsigned long long  UINT64, *PUINT64, ULONGLONG;
 
-#if defined(__x86_64__)
+#if __SIZEOF_POINTER__ == 8
 typedef long long INT_PTR, *PINT_PTR;
 typedef unsigned long long UINT_PTR, *PUINT_PTR;
 


### PR DESCRIPTION
On aarch64 the build fails:

```
../DiscImageCreator/_linux/defineForLinux.h:1474:50: error: cast from
'PDISK_PARTITION_INFO' to 'UINT_PTR' {aka 'unsigned int'} loses precision
```

`UINT_PTR` and friends are only 64-bit when `__x86_64__` is defined. aarch64 is 64-bit too, so it gets a 32-bit type for a 64-bit pointer.

Fix: test pointer size instead of CPU.

```diff
-#if defined(__x86_64__)
+#if __SIZEOF_POINTER__ == 8
```

Same branch on x86_64, so nothing changes there.

Tested on Fedora 43, full tree (meson/ninja): aarch64 fails before, builds after. x86_64 still builds.

*Prepared with AI assistance (Claude Opus 4.8) and reviewed before submission.*
